### PR TITLE
use AppCompat progress style

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -27,7 +27,7 @@
 
     <ProgressBar
         android:id="@+id/loading_spinner"
-        style="@android:style/Widget.ProgressBar.Inverse"
+        style="@style/Widget.AppCompat.ProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"


### PR DESCRIPTION
Fix progress bar style.
After Android 5.0, progress color becomes `colorAccent`.
In Android 4.4, progress style is device's original style.

before
![before](https://cloud.githubusercontent.com/assets/5267827/21576535/6e6248ee-cf77-11e6-9cd3-e36980bf3a13.png)

after
![after](https://cloud.githubusercontent.com/assets/5267827/21576537/74c96564-cf77-11e6-86c0-cfadc5019af9.png)
(Images are in Android 6.0)